### PR TITLE
Fix jdee function naming

### DIFF
--- a/src/main/groovy/com/mattwhipple/gradle/JdeePlugin.groovy
+++ b/src/main/groovy/com/mattwhipple/gradle/JdeePlugin.groovy
@@ -7,30 +7,30 @@ class JdeePlugin implements Plugin<Project> {
 
   def prj = { project ->
 
-    "(jde-project-file-version" (["1.0"])
-    "(jde-set-variables" { 
-      "'(jde-compile-option-directory" ([project.sourceSets.main.output.classesDir])
-      "'(jde-junit-working-directory" ([project.projectDir])
+    "(jdee-project-file-version" (["1.0"])
+    "(jdee-set-variables" { 
+      "'(jdee-compile-option-directory" ([project.sourceSets.main.output.classesDir])
+      "'(jdee-junit-working-directory" ([project.projectDir])
     
-      "'(jde-compile-option-source" { 
+      "'(jdee-compile-option-source" { 
 	"'(" (["default"])
       }
 
-      "'(jde-compile-option-target" { 
+      "'(jdee-compile-option-target" { 
 	"'(" (["default"])
       }
 
-      "'(jde-compile-option-command-line-args" { 
+      "'(jdee-compile-option-command-line-args" { 
 	"'(" (["-${project.sourceCompatibility}"])
       }
     
-      "'(jde-sourcepath" { 
+      "'(jdee-sourcepath" { 
 	"'(" (
 	  project.sourceSets.main.allSource.srcDirs 
 	  + project.sourceSets.test.allSource.srcDirs)
       }
     
-      "'(jde-global-classpath" { 
+      "'(jdee-global-classpath" { 
 	"'(" (
 	  [] + project.sourceSets.main.output.classesDir
 	  + project.sourceSets.test.output.classesDir


### PR DESCRIPTION
In https://github.com/jdee-emacs/jdee/commit/58c290b4, names starting prefixed with jde- were changed to be prefixed with jdee-. This PR updates prj.el to use the new naming convention.
